### PR TITLE
Fix change user to root

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `process_exporter_config_dir` | "/etc/process_exporter" | Path to directory with process_exporter configuration |
 | `process_exporter_names` | [see: defaults/main.yml](defaults/main.yml#L8) | Processes which should be monitored. Syntax is the same as in https://github.com/ncabatoff/process-exporter#using-a-config-file Default is consistent with deb/rpm packages.|
 | `process_exporter_system_user`| "process-exp" | System user under which the process_explorer will run. Useful change to "root" if you need some metrics like proportionalResident memory bytes.|
-| `process_exporter_system_group`| "process-exp" | System group under which the process_explorer will run.
-|
+| `process_exporter_system_group`| "process-exp" | System group under which the process_explorer will run.|
+
 
 `process_exporter_names` handling has been set up in an unusual way to handle recommended process-exporter 'Template variables' (such as {{.Comm}}). Follow the example in [defaults/main.yml](defaults/main.yml) if you want to define custom filtering/grouping of processes that use Template variables and make sure to keep the {% raw %} block delimiters.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `process_exporter_web_listen_address` | "0.0.0.0:9256" | Address on which process_exporter will listen |
 | `process_exporter_config_dir` | "/etc/process_exporter" | Path to directory with process_exporter configuration |
 | `process_exporter_names` | [see: defaults/main.yml](defaults/main.yml#L8) | Processes which should be monitored. Syntax is the same as in https://github.com/ncabatoff/process-exporter#using-a-config-file Default is consistent with deb/rpm packages.|
+| `process_exporter_system_user`| "process-exp" | System user under which the process_explorer will run. Useful change to "root" if you need some metrics like proportionalResident memory bytes.|
+| `process_exporter_system_group`| "process-exp" | System group under which the process_explorer will run.
+|
 
 `process_exporter_names` handling has been set up in an unusual way to handle recommended process-exporter 'Template variables' (such as {{.Comm}}). Follow the example in [defaults/main.yml](defaults/main.yml) if you want to define custom filtering/grouping of processes that use Template variables and make sure to keep the {% raw %} block delimiters.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@ process_exporter_web_listen_address: "0.0.0.0:9256"
 
 process_exporter_config_dir: '/etc/process_exporter'
 
+process_exporter_system_user: "process-exp"
+process_exporter_system_group: "process-exp"
+
 # Process names
 # "raw" section is needed to avoid attempted interpretation
 # of process-exporter Template varables (like {{.Comm}})

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,5 +8,3 @@ go_arch_map:
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
 
-process_exporter_system_user: "process-exp"
-process_exporter_system_group: "process-exp"


### PR DESCRIPTION
Due to variable precedence, it is impossible to install the program as root. This PR solves the problem.
The ability to change the user is also described in the readme. There is an important reasons to change the default user.