### PR TITLE
Add ability to change system user, group and binary install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Note. This repository and role uses the name process_exporter to conform with an
 ## Requirements
 
 - Ansible >= 2.7 (It might work on previous versions, but we cannot guarantee it)
+- GNU Tar (If you are using macOS, install it using `brew install gnu-tar`)
 
 ## Role Variables
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `process_exporter_version` | 0.7.5 | Process exporter package version. Also accepts latest as parameter |
 | `process_exporter_web_listen_address` | "0.0.0.0:9256" | Address on which process_exporter will listen |
 | `process_exporter_config_dir` | "/etc/process_exporter" | Path to directory with process_exporter configuration |
+| `process_exporter_bin_dir` | "/usr/local/bin" | Path to directory with process_exporter binary file |
+| `process_exporter_system_user` | "process-exp" | System user for process_exporter |
+| `process_exporter_system_group` | "process-exp" | System group for process_exporter |
 | `process_exporter_names` | [see: defaults/main.yml](defaults/main.yml#L8) | Processes which should be monitored. Syntax is the same as in https://github.com/ncabatoff/process-exporter#using-a-config-file Default is consistent with deb/rpm packages.|
 
 `process_exporter_names` handling has been set up in an unusual way to handle recommended process-exporter 'Template variables' (such as {{.Comm}}). Follow the example in [defaults/main.yml](defaults/main.yml) if you want to define custom filtering/grouping of processes that use Template variables and make sure to keep the {% raw %} block delimiters.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name           | Default Value | Description                        |
 | -------------- | ------------- | -----------------------------------|
-| `process_exporter_version` | 0.7.5 | Process exporter package version. Also accepts latest as parameter |
+| `process_exporter_version` | 0.7.10 | Process exporter package version. Also accepts latest as parameter |
 | `process_exporter_web_listen_address` | "0.0.0.0:9256" | Address on which process_exporter will listen |
 | `process_exporter_config_dir` | "/etc/process_exporter" | Path to directory with process_exporter configuration |
 | `process_exporter_bin_dir` | "/usr/local/bin" | Path to directory with process_exporter binary file |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-process_exporter_version: 0.7.5
+process_exporter_version: 0.7.10
 
 process_exporter_web_listen_address: "0.0.0.0:9256"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@ process_exporter_web_listen_address: "0.0.0.0:9256"
 
 process_exporter_config_dir: '/etc/process_exporter'
 
+process_exporter_system_user: "process-exp"
+process_exporter_system_group: "process-exp"
+
 # Process names
 # "raw" section is needed to avoid attempted interpretation
 # of process-exporter Template varables (like {{.Comm}})

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ process_exporter_version: 0.7.5
 process_exporter_web_listen_address: "0.0.0.0:9256"
 
 process_exporter_config_dir: '/etc/process_exporter'
+process_exporter_bin_dir: '/usr/local/bin'
 
 process_exporter_system_user: "process-exp"
 process_exporter_system_group: "process-exp"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -59,16 +59,16 @@
   delegate_to: localhost
   check_mode: false
 
-- name: Create /usr/local/bin
+- name: Ensure binary directory exists
   file:
-    path: /usr/local/bin
+    path: "{{ process_exporter_bin_dir }}"
     state: directory
     mode: 0755
 
 - name: Propagate process_exporter binaries
   copy:
     src: "/tmp/process-exporter-{{ process_exporter_version }}.linux-{{ go_arch }}/process-exporter"
-    dest: "/usr/local/bin/process_exporter"
+    dest: "{{ process_exporter_bin_dir }}/process_exporter"
     mode: 0755
     owner: root
     group: root

--- a/templates/process_exporter.service.j2
+++ b/templates/process_exporter.service.j2
@@ -9,7 +9,7 @@ StartLimitInterval=0
 Type=simple
 User={{ process_exporter_system_user }}
 Group={{ process_exporter_system_group }}
-ExecStart=/usr/local/bin/process_exporter \
+ExecStart={{ process_exporter_bin_dir }}/process_exporter \
 {% if process_exporter_names != [] -%}
 	--config.path {{ process_exporter_config_dir }}/config.yml \
 {% endif -%}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,3 @@ go_arch_map:
   armv6l: 'armv6'
 
 go_arch: "{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"
-
-process_exporter_system_user: "process-exp"
-process_exporter_system_group: "process-exp"


### PR DESCRIPTION
Hello everyone. I made some changes:

1. Moved `process_exporter_system_user` and `process_exporter_system_group` to get ability to change it with inventory variables.
2. Added `process_exporter_bin_dir` variable to get ability to install process_exporter to different locations.
3. Bumped `process_exporter_version` to 0.7.10 (latest).
4. Added notes about variables to README.md
5. Added gnu tar to requirements in README.